### PR TITLE
Add shebang to Python script

### DIFF
--- a/toggl2openerp.py
+++ b/toggl2openerp.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import pandas as pd
 import sys
 


### PR DESCRIPTION
The shebang allows the direct execution of the script.

I've added an explicit shebang for Python 3 since Python 2 has been sunset, but if you prefer a more generic I'll make the changes accordingly.

This has been tested on Ubuntu 20.04 LTS inside a venv with Python 3.8.3 and Pandas 1.1.4 installed with Pip.